### PR TITLE
Support quoted modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Bug fixes
+  * Allow checking modules that are defined in a `quote` block inside a `defmacro`
+
 ## v0.2.1
 
 * Bug fixes

--- a/lib/credo/checks/pure_module_check.ex
+++ b/lib/credo/checks/pure_module_check.ex
@@ -142,7 +142,11 @@ defmodule Credo.Check.Custom.PureModule do
        ) do
     # Need to get the full module name by resolving it within the scope of the
     # ast in case it is a submodule
-    {:defmodule, mod_full_name} = Credo.Code.Scope.name(source_ast, [line])
+    mod_full_name =
+      case Credo.Code.Scope.name(source_ast, [line]) do
+        {:defmodule, mod_full_name} -> mod_full_name
+        {:defmacro, mod_full_name} -> mod_full_name
+      end
 
     mod_deps = get_dependencies(ast)
 
@@ -171,7 +175,11 @@ defmodule Credo.Check.Custom.PureModule do
         [opts] -> Keyword.get(opts, :force, false)
       end
 
-    {:defmodule, mod_full_name} = Credo.Code.Scope.name(source_ast, [line])
+    mod_full_name =
+      case Credo.Code.Scope.name(source_ast, [line]) do
+        {:defmodule, mod_full_name} -> mod_full_name
+        {:defmacro, mod_full_name} -> mod_full_name
+      end
 
     acc =
       Map.update!(acc, mod_full_name, fn ms ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CredoPureCheck.MixProject do
   def project do
     [
       app: :credo_pure_check,
-      version: "0.2.1",
+      version: "0.2.2",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
when having something like:

```
defmodule MyMod do
  defmacro __using__(_opts) do
    quote do
      defmodule QuotedMod do
     ....
```

the credo crashes with error

```
    ** (MatchError) no match of right hand side value: {:defmacro, "MyMod.__using__"}
        lib/credo/checks/pure_module_check.ex:145: Credo.Check.Custom.PureModule.traverse/4
```

This pr solves this case