### PR TITLE
Passing a range with negative step is deprecated

### DIFF
--- a/lib/credo/checks/pure_module_check.ex
+++ b/lib/credo/checks/pure_module_check.ex
@@ -322,7 +322,7 @@ defmodule Credo.Check.Custom.PureModule do
     Enum.member?(project_mods, mod) or
       Enum.any?(lib_mods, fn lib_mod ->
         if String.ends_with?(lib_mod, ".*") do
-          String.starts_with?(mod, String.slice(lib_mod, 0..-2))
+          String.starts_with?(mod, String.slice(lib_mod, 0..-2//1))
         else
           mod == lib_mod
         end


### PR DESCRIPTION
In the [Enum.slice/2](https://hexdocs.pm/elixir/Enum.html#slice/2) was added the following deprecation warning:

https://hexdocs.pm/elixir/changelog.html#4-hard-deprecations

This change fix the respective warning:

```
warning: negative steps are not supported in String.slice/2, pass 0..-2//1 instead
   (elixir 1.16.0) lib/string.ex:2368: String.slice/2
   (credo_pure_check 0.2.2) lib/credo/checks/pure_module_check.ex:325: anonymous fn/2 in Credo.Check.Custom.PureModule.pure_mod?/3
   (elixir 1.16.0) lib/enum.ex:4202: Enum.predicate_list/3
   (credo_pure_check 0.2.2) lib/credo/checks/pure_module_check.ex:323: Credo.Check.Custom.PureModule.pure_mod?/3
   (elixir 1.16.0) lib/enum.ex:4405: Enum.reject_list/2
   (credo_pure_check 0.2.2) lib/credo/checks/pure_module_check.ex:304: anonymous fn/4 in Credo.Check.Custom.PureModule.create_issues/2
```

I have tested this approach in the elixir versions `1.14`, `1.15`, and `1.16`